### PR TITLE
Fix protocol description

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -1,4 +1,3 @@
-
 Network protocol used by GfxTablet
 
 
@@ -8,21 +7,21 @@ Version 1
 
 GfxTablet app sends UDP packets to port 40118 of the destination host.
 
-Packet structure:
+Packet structure, uses network byte order (big endian):
 
-  9  octets   "GfxTablet"
-  1  ushort   version number
-  1  ushort   type:
-              0 motion event (hovering)
-              1 button event (finger, pen etc. touches surface)
+  9  bytes    "GfxTablet"
+  1  word     version number
+  1  byte     type:
+                0 motion event (hovering)
+                1 button event (finger, pen etc. touches surface)
 
-  1  ushort   x (using full range: 0..65535)
-  1  ushort   y (using full range: 0..65535)
-  1  ushort   pressure (using full range 0..65535, 32768 == pressure 1.0f on Android device)
+  1  word     x (using full range: 0..65535)
+  1  word     y (using full range: 0..65535)
+  1  word     pressure (using full range 0..65535, 32768 == pressure 1.0f on Android device)
 
-when type == button event:
+  when type == button event:
   1  byte     number of button, starting with 0
   1  byte     button status:
-              0 button is down
-              1 button is up
+                0 button is down
+                1 button is up
 


### PR DESCRIPTION
doc/protocol.txt: Replaced type names with architecture independent aliases, fixed 'type' size which is a byte, and recorded that it uses "big endian", or "network byte order" convention.
