### PR TITLE
Eyecandy color Mod + GIMP Pressure Curve fix initial

### DIFF
--- a/driver-uinput/README
+++ b/driver-uinput/README
@@ -1,0 +1,49 @@
+GfxTablet network manager daemon.
+Protocol version 1.0 -- quadcore-dev proposed commit.
+
+This code has been modified from it's original source on
+GitHub -- https://github.com/edtrind/GfxTablet-master
+Author:  bitfire web engineering/GfxTablet -- Richard Hirner
+http://rfc2822.github.io/GfxTablet/
+
+Modified by quadcore-dev/loopyd - Robert Smith
+lupinedreamexpress@gmail.com
+
+This version provides higher compatability for GIMP (by
+converting the output values to larger ones so that the
+pressure curve function becomes usable in "Input Settings"
+-> "Network Tablet".
+
+It also contains some eyecandy, a visible pressure bar that
+indicates how hard your last stroke was.  It does not spam
+your terminal window with the events, but will exit with
+an error code if there is a problem.
+
+This code was tested on Ubuntu 14.04 LTS Studio and is
+verified working on this platform.
+
+I am not responsible if my code causes your GfxTablet
+daemon to stop functioning, your computer to catch fire,
+or your pets to die from said fire, etc.
+
+---
+
+Modified:
+
+	networktablet.c	- network tablet daemon
+
+Added:
+
+	qccolor.h	- eyecandy for your terminal
+	README 		- this file
+
+Deleted:
+
+	None
+
+--
+
+Have a wonderful life!
+
+~quadcore-dev/loopyd
+"We write code because we like to."

--- a/driver-uinput/qccolor.h
+++ b/driver-uinput/qccolor.h
@@ -1,0 +1,96 @@
+// qccolor.h -- Some color effects for your terminal!
+//
+// By quadcore-dev/loopyd -- Robert Smith
+// lupinedreamexpress@gmail.com
+//
+// Replacement for conio.h.  This module contains some
+// eyecandy for your terminal.  Including a color set
+// subroutine and a neat little progress bar routine!
+//
+// By quadcore-dev on GitHub
+// "We write code because we like to!"
+//
+#pragma once
+
+#define RESET       0
+#define BRIGHT      1
+#define DIM         2
+#define UNDERLINE   3
+#define BLINK       4
+#define REVERSE     7
+#define HIDDEN      8
+#define BLACK       0
+#define RED         1
+#define GREEN       2
+#define YELLOW      3
+#define BLUE        4
+#define MAGENTA     5
+#define CYAN        6
+#define WHITE       7
+
+void textcolor(int attr, int fg, int bg);
+void reset_screen(void);
+void progbar(short ipVal, short ipMaxVal);
+
+// textcolor by QuadCore -- Sets text color at current cursor 
+// position.
+//
+// int attr - Color attribute
+// int fg   - Foreground color
+// int bg   - Background color
+//
+void textcolor(int attr, int fg, int bg)
+{   
+    char command[13];
+    sprintf(command, "%c[%d;%d;%dm", 0x1B, attr, fg + 30, bg + 40);
+    printf("%s", command);
+}
+
+// cls_screen by QuadCore -- Clears screen of all text
+//
+// Nothing.  (void)
+//
+void cls_screen(void)
+{
+    system("reset");
+    return;
+}
+
+// progbar by QuadCore -- Draw a simple progress bar
+//
+// int ipVal    = Current Value.
+// int ipMaxVal = Max Value.
+//
+// Don't pass large values or you'll get a large progress 
+// bar!  Convert them first using a ratio!  Also don't
+// pass 0 for ipMaxVal or you get divison by zero crash!
+//
+void progbar(short ipVal, short ipMaxVal) {
+	
+	short iProgC = ipVal;
+	
+	int ipColor = 0;
+	if ((float) ((float) ipVal / (float) ipMaxVal) <= 0.25f) {
+		ipColor = BLUE;
+	}
+	if ((float) ((float) ipVal / (float) ipMaxVal) > 0.25f) {
+		ipColor = GREEN;
+	}
+	if ((float) ((float) ipVal / (float) ipMaxVal) > 0.65f) {
+		ipColor = YELLOW;
+	}
+	if ((float) ((float) ipVal / (float) ipMaxVal) > 0.85f) {
+		ipColor = RED;
+ 	}
+	
+	iProgC = ipMaxVal - ipVal;
+        while (iProgC++ <= ipMaxVal && iProgC != 0) {
+		textcolor (DIM, ipColor, ipColor);
+                printf (" ");
+        }
+	iProgC = ipVal;
+	while (iProgC++ <= ipMaxVal) {
+		textcolor (DIM, WHITE, WHITE);
+		printf ("_"); 
+	}
+}


### PR DESCRIPTION
This is a proposed fix for the GIMP pressure curve problem.  Initially you must squash the pressure curve to make Networktablet properly function inside of gimp.  This fix allows you to use the entire curve by expanding the short int pessure value to a long using a ratio.

This fix also makes the networktablet window a lot more pleasing to the eye.  Included is a pressure bar that changes color and size depending on your last pressure applied to the screen, which updates in real time.

What do you guys think?

I'm new to C++...but if you have any suggestions let me know!

Tested and functioning on Ubuntu 14.04 LTS Studio.
![pressure_bar](https://cloud.githubusercontent.com/assets/11514857/6697573/ccd5e110-ccc7-11e4-84a4-d611d50951c8.png)
