### PR TITLE
Use unsigned shorts as for value range

### DIFF
--- a/app-android/app/src/main/java/at/bitfire/gfxtablet/CanvasView.java
+++ b/app-android/app/src/main/java/at/bitfire/gfxtablet/CanvasView.java
@@ -124,17 +124,18 @@ public class CanvasView extends View implements SharedPreferences.OnSharedPrefer
 		return false;
 	}
 	
-	
+	// these overflow and wrap around to negative short values, but thankfully Java will continue
+	// on regardless, so we can just ignore Java's interpretation of them and send them anyway.
 	short normalizeX(float x) {
-		return (short)(Math.min(Math.max(0, x), maxX) * Short.MAX_VALUE/maxX);
+		return (short)(Math.min(Math.max(0, x), maxX) * 2*Short.MAX_VALUE/maxX);
 	}
 	
 	short normalizeY(float x) {
-		return (short)(Math.min(Math.max(0, x), maxY) * Short.MAX_VALUE/maxY);
+		return (short)(Math.min(Math.max(0, x), maxY) * 2*Short.MAX_VALUE/maxY);
 	}
 	
 	short normalizePressure(float x) {
-		return (short)(Math.min(Math.max(0, x), 2.0) * Short.MAX_VALUE/2.0);
+		return (short)(Math.min(Math.max(0, x), 2.0) * Short.MAX_VALUE);
 	}
 
 }

--- a/app-android/app/src/main/java/at/bitfire/gfxtablet/NetEvent.java
+++ b/app-android/app/src/main/java/at/bitfire/gfxtablet/NetEvent.java
@@ -15,7 +15,7 @@ public class NetEvent {
 		TYPE_DISCONNECT
 	}
 	static final String signature = "GfxTablet";
-	static final short protocol_version = 1;
+	static final short protocol_version = 2;
 	
 	final Type type;
 	short x, y, pressure;

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -2,26 +2,26 @@ Network protocol used by GfxTablet
 
 
 
-Version 1
+Version 2
 ---------
 
 GfxTablet app sends UDP packets to port 40118 of the destination host.
 
 Packet structure, uses network byte order (big endian):
 
-  9  bytes    "GfxTablet"
-  1  word     version number
-  1  byte     type:
-                0 motion event (hovering)
-                1 button event (finger, pen etc. touches surface)
+  9  bytes             "GfxTablet"
+  1  unsigned int16     version number
+  1  byte             event type:
+                        0: motion event (hovering)
+                        1: button event (finger, pen etc. touches surface)
 
-  1  word     x (using full range: 0..65535)
-  1  word     y (using full range: 0..65535)
-  1  word     pressure (using full range 0..65535, 32768 == pressure 1.0f on Android device)
+  1  unsigned int16     x (using full range: 0..65535)
+  1  unsigned int16     y (using full range: 0..65535)
+  1  unsigned int16     pressure (accepting full range 0..65535, but will clip to 32768 == pressure 1.0f on Android device)
 
   when type == button event:
-  1  byte     number of button, starting with 0
-  1  byte     button status:
-                0 button is released ("up")
-                1 button is pressed ("down")
+  1  signed int8        number of button, starting with 0
+  1  byte             button status:
+                        0 button is released ("up")
+                        1 button is pressed ("down")
 

--- a/driver-uinput/Makefile
+++ b/driver-uinput/Makefile
@@ -1,5 +1,5 @@
 
-networktablet : networktablet.c protocol.h
+networktablet : networktablet.c
 
 clean :
 	rm networktablet

--- a/driver-uinput/networktablet.c
+++ b/driver-uinput/networktablet.c
@@ -10,6 +10,7 @@
 #include <arpa/inet.h>
 #include <linux/input.h>
 #include <linux/uinput.h>
+#include <stdint.h>
 #include "protocol.h"
 
 #define die(str, args...) { \
@@ -52,11 +53,11 @@ void init_device(int fd)
 	uidev.id.product = 0x1;
 	uidev.id.version = 1;
 	uidev.absmin[ABS_X] = 0;
-	uidev.absmax[ABS_X] = SHRT_MAX;
+	uidev.absmax[ABS_X] = UINT16_MAX;
 	uidev.absmin[ABS_Y] = 0;
-	uidev.absmax[ABS_Y] = SHRT_MAX;
+	uidev.absmax[ABS_Y] = UINT16_MAX;
 	uidev.absmin[ABS_PRESSURE] = 0;
-	uidev.absmax[ABS_PRESSURE] = SHRT_MAX/2;
+	uidev.absmax[ABS_PRESSURE] = INT16_MAX;
 	if (write(fd, &uidev, sizeof(uidev)) < 0)
 		die("error: write");
 
@@ -132,7 +133,7 @@ int main(void)
 		ev_pkt.x = ntohs(ev_pkt.x);
 		ev_pkt.y = ntohs(ev_pkt.y);
 		ev_pkt.pressure = ntohs(ev_pkt.pressure);
-		printf("x: %hi, y: %hi, pressure: %hi\n", ev_pkt.x, ev_pkt.y, ev_pkt.pressure);
+		printf("x: %hu, y: %hu, pressure: %hu\n", ev_pkt.x, ev_pkt.y, ev_pkt.pressure);
 
 		send_event(device, EV_ABS, ABS_X, ev_pkt.x);
 		send_event(device, EV_ABS, ABS_Y, ev_pkt.y);

--- a/driver-uinput/protocol.h
+++ b/driver-uinput/protocol.h
@@ -1,7 +1,6 @@
-
 #define GFXTABLET_PORT 40118
 
-#define PROTOCOL_VERSION 1
+#define PROTOCOL_VERSION 2
 
 
 #pragma pack(push)
@@ -13,16 +12,16 @@
 struct event_packet
 {
 	char signature[9];
-	unsigned short version;
-	char type;	/* EVENT_TYPE_... */
+	uint16_t version;
+	uint8_t type;	/* EVENT_TYPE_... */
 	struct {	/* required */
-		short x, y;
-		short pressure;
+		uint16_t x, y;
+		uint16_t pressure;
 	};
 
 	struct {	/* only required for EVENT_TYPE_BUTTON */
-		char button;		/* number of button, beginning with 1 */
-		char down;		/* 1 = button down, 0 = button up */
+		int8_t button;		/* number of button, beginning with 1 */
+		int8_t down;		/* 1 = button down, 0 = button up */
 	};
 };
 


### PR DESCRIPTION
The protocol documentation says x, y, and pressure range from 0 to 65535; in practice they ranged to 32767. This PR updates the code to match the documentation. It also changes the protocol to use standard integer types in C99 to try and remove any hint of ambiguity.