### PR TITLE
Makefile fixes

### DIFF
--- a/driver-uinput/Makefile
+++ b/driver-uinput/Makefile
@@ -2,4 +2,4 @@
 networktablet : networktablet.c protocol.h
 
 clean :
-	rm networktablet
+	rm -f networktablet

--- a/driver-uinput/Makefile
+++ b/driver-uinput/Makefile
@@ -1,5 +1,11 @@
+TARGET = networktablet
+PREFIX = /usr/local
+BINDIR = $(PREFIX)/bin
 
 networktablet : networktablet.c protocol.h
 
 clean :
 	rm -f networktablet
+
+install :
+	install -D networktablet $(DESTDIR)$(BINDIR)/networktablet


### PR DESCRIPTION
Fix make clean so it doesn't complain if called on an already clean directory, and implement basic make install.

These fixes are both to make it easier to maintain a debian package for networktablet. :) They are also relevant to general non-debian use.