### PR TITLE
Simplify driver code, add IPv6 support

### DIFF
--- a/driver-uinput/Makefile
+++ b/driver-uinput/Makefile
@@ -1,11 +1,11 @@
-TARGET = networktablet
-PREFIX = /usr/local
+PREFIX ?= /usr/local
+CFLAGS ?= -Wall -g
 BINDIR = $(PREFIX)/bin
 
-networktablet : networktablet.c
+networktablet:
 
-clean :
-	rm -f networktablet
+clean:
+	$(RM) networktablet
 
-install :
-	install -D networktablet $(DESTDIR)$(BINDIR)/networktablet
+install:
+	install -D networktablet "$(DESTDIR)$(BINDIR)/networktablet"

--- a/driver-uinput/protocol.h
+++ b/driver-uinput/protocol.h
@@ -1,14 +1,12 @@
-#define GFXTABLET_PORT 40118
-
+#define GFXTABLET_DEFAULT_HOST "::"
+#define GFXTABLET_DEFAULT_PORT "40118"
 #define PROTOCOL_VERSION 2
-
-
-#pragma pack(push)
-#pragma pack(1)
 
 #define EVENT_TYPE_MOTION 0
 #define EVENT_TYPE_BUTTON 1
 
+#pragma pack(push)
+#pragma pack(1)
 struct event_packet
 {
 	char signature[9];
@@ -28,5 +26,4 @@ struct event_packet
 		int8_t down;		/* 1 = button down, 0 = button up */
 	};
 };
-
 #pragma pack(pop)


### PR DESCRIPTION
The code style of the driver could be improved further (for my tastes), but I've left it to some minor cleanups now.

The driver is now listening on a dual-stack socket (capable of receiving IPv4 and IPv6 connections on systems that support it, which should be most), with a default host of `::`.
Proper creation of the listening socket (with `getaddrinfo`) is actually the reason why I've decided to create this PR ;)

The host to bind to and the port to listen on can optionally be supplied as command line arguments.

The makefile has been simplified and options for increased compiler warning verbosity have been added.

I've also taken the liberty of supplying some more expressive error messages.

*CAVEAT*: I have not really tested this other than running it and hitting it with `nc`.
Some real-world regression testing would probably be useful, though I don't really expect any problems.

Keep up the good work :)